### PR TITLE
Remove magic TARGET_GENERATED_SOURCES_JOOQ

### DIFF
--- a/core/src/main/java/com/freenow/jooqcontainers/core/AbstractGenerator.java
+++ b/core/src/main/java/com/freenow/jooqcontainers/core/AbstractGenerator.java
@@ -101,7 +101,7 @@ public abstract class AbstractGenerator
     }
 
 
-    public static void setJooqTargetDirectory(Configuration jooqConfig, String targetDirectory)
+    public static void setJooqTargetDirectory(Configuration jooqConfig)
     {
         if (jooqConfig.getGenerator() == null)
         {
@@ -113,7 +113,7 @@ public abstract class AbstractGenerator
             jooqConfig.getGenerator().setTarget(new Target());
         }
 
-        jooqConfig.getGenerator().getTarget().setDirectory(Paths.get(targetDirectory).toAbsolutePath().toString());
+        jooqConfig.getGenerator().getTarget().setDirectory(Paths.get(jooqConfig.getGenerator().getTarget().getDirectory()).toAbsolutePath().toString());
     }
 
 

--- a/liquibase-pg/src/main/java/com/freenow/jooqcontainers/maven/liquibase/pg/LiquibasePgGenerateMojo.java
+++ b/liquibase-pg/src/main/java/com/freenow/jooqcontainers/maven/liquibase/pg/LiquibasePgGenerateMojo.java
@@ -12,8 +12,6 @@ import org.jooq.meta.jaxb.Configuration;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class LiquibasePgGenerateMojo extends AbstractMojo
 {
-    private static final String TARGET_GENERATED_SOURCES_JOOQ = "target/generated-sources/jooq/";
-
     @Parameter(property = "generate.jooq", required = true)
     private Configuration jooq = new Configuration();
 
@@ -37,10 +35,10 @@ public class LiquibasePgGenerateMojo extends AbstractMojo
     public void execute()
     {
         String liquibaseChangeLogFile = (String) liquibase.get("changeLogFile");
-        LiquibaseGenerator.setJooqTargetDirectory(jooq, TARGET_GENERATED_SOURCES_JOOQ);
+        LiquibaseGenerator.setJooqTargetDirectory(jooq);
         LiquibaseGenerator generator;
 
-        project.addCompileSourceRoot(TARGET_GENERATED_SOURCES_JOOQ);
+        project.addCompileSourceRoot(jooq.getGenerator().getTarget().getDirectory());
 
         if (databaseVersion != null)
         {

--- a/liquibase/src/main/java/com/freenow/jooqcontainers/maven/liquibase/LiquibaseGenerateMojo.java
+++ b/liquibase/src/main/java/com/freenow/jooqcontainers/maven/liquibase/LiquibaseGenerateMojo.java
@@ -12,8 +12,6 @@ import org.jooq.meta.jaxb.Configuration;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class LiquibaseGenerateMojo extends AbstractMojo
 {
-    private static final String TARGET_GENERATED_SOURCES_JOOQ = "target/generated-sources/jooq/";
-
     @Parameter(property = "generate.jooq", required = true)
     private Configuration jooq = new Configuration();
 
@@ -35,9 +33,9 @@ public class LiquibaseGenerateMojo extends AbstractMojo
         String tcDatabaseName = (String) testcontainers.get("databaseName");
         String tcDatabaseVersion = (String) testcontainers.get("databaseVersion");
 
-        LiquibaseGenerator.setJooqTargetDirectory(jooq, TARGET_GENERATED_SOURCES_JOOQ);
+        LiquibaseGenerator.setJooqTargetDirectory(jooq);
 
-        project.addCompileSourceRoot(TARGET_GENERATED_SOURCES_JOOQ);
+        project.addCompileSourceRoot(jooq.getGenerator().getTarget().getDirectory());
 
         LiquibaseGenerator generator;
 


### PR DESCRIPTION
is't solve the problem with a multi-module project.
Generator always creates target dir in the parent module, now start use property jooq.generator.target.directory